### PR TITLE
Do not evaluate variables on assignment

### DIFF
--- a/lib/kalc/ast.rb
+++ b/lib/kalc/ast.rb
@@ -205,7 +205,7 @@ module Kalc
       end
 
       def eval(context)
-        context.add_variable(@variable, @value.eval(context))
+        context.add_variable(@variable, @value)
       end
     end
 
@@ -219,7 +219,7 @@ module Kalc
       def eval(context)
         var = context.get_variable(@variable)
         fail "Invalid variable: #{@variable}" unless var
-        var
+        var.class == BigDecimal ? var : var.eval(context)
       end
     end
 


### PR DESCRIPTION
Variables might be defined later, so the evaluation should be done when evaluating a variable were the context should be complete

So ```Kalc::Runner.new.run('a:=b+1; b:=2; a')``` shouldn't fail but ```Kalc::Runner.new.run('a:=b+1; a')``` should fail when evaluating a, not when defining it. 