### PR TITLE
transform left as Ast:Ops IF theres an operator

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    kalc (1.1.0)
+    kalc (1.1.1)
       parslet (~> 1.7)
 
 GEM
@@ -36,4 +36,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   1.10.3
+   1.10.6

--- a/lib/kalc/transform.rb
+++ b/lib/kalc/transform.rb
@@ -5,10 +5,6 @@ module Kalc
       condition
     }
 
-    rule(:left => subtree(:left), :ops => []) {
-      left
-    }
-
     rule(:right => subtree(:right), :ops => []) {
       right
     }
@@ -62,7 +58,7 @@ module Kalc
     }
 
     rule(:left => simple(:left), :ops => subtree(:ops)) {
-      Ast::Ops.new(left, ops)
+      ops.empty? ? left : Ast::Ops.new(left, ops)
     }
 
     rule(:left => simple(:left), :right => simple(:right), :operator => simple(:operator)) {


### PR DESCRIPTION
This PR simplifies the AST structure being generated after the update to parslet 1.7.0.

For some reason, the rule rule(:left => subtree(:left), :ops => []) was not being reached and the syntax tree generated was more complex than it should.

A simple operation such as a:=1 was being transformed into 6 levels of empty Ast::Ops until it actually reached the number.

Here I'm just verifying that if ops is empty, it should call to left without any other argument, otherwise build the Ast::Ops object.